### PR TITLE
ShiftFinder Class

### DIFF
--- a/lib/key_maker.rb
+++ b/lib/key_maker.rb
@@ -2,6 +2,7 @@ class KeyMaker
   attr_accessor :key
   def initialize(key = nil)
     @key = generate(key)
+    @keys = {}
     # @a_key = key[0..1]
     # @b_key = key[1..2]
     # @c_key = key[2..3]
@@ -18,9 +19,10 @@ class KeyMaker
   end
 
   def generate_four_keys(key)
-    a_key = key[0..1]
-    b_key = key[1..2]
-    c_key = key[2..3]
-    d_key = key[3..4]
+    @keys["A"] = (a_key = key[0..1])
+    @keys["B"] = (b_key = key[1..2])
+    @keys["C"] = (c_key = key[2..3])
+    @keys["D"] = (d_key = key[3..4])
+    @keys
   end
 end

--- a/lib/shift_finder.rb
+++ b/lib/shift_finder.rb
@@ -1,0 +1,18 @@
+class ShiftFinder
+  def initialize(keys, offsets)
+    @keys = keys
+    @offsets = offsets
+  end
+
+  def sum_of_keys_and_offsets(keys, offsets)
+    shifts = keys.merge(offsets) do |k, keys, offsets|
+      (keys.to_i + offsets.to_i).to_s
+    end
+  end
+end
+
+# module Shiftable
+#   def sum_of_keys_and_offsets(keys, offsets)
+#     shift = (keys + offsets)
+#     a_hash.merge(b_hash){ |k, a_value, b_value| a_value + b_value }
+# end

--- a/spec/key_maker_spec.rb
+++ b/spec/key_maker_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe KeyMaker do
     expect(key_maker_random.key).to be_instance_of(String)
     expect(key_maker_random.key.length).to be(5)
   end
+
+  it 'can generate four new keys' do
+    key_maker = KeyMaker.new("02715")
+    expect(key_maker.generate_four_keys("02715")).to eq({"A" => "02",
+      "B" => "27", "C" => "71", "D" => "15"})
+  end
+
 end

--- a/spec/shift_finder_spec.rb
+++ b/spec/shift_finder_spec.rb
@@ -1,0 +1,28 @@
+require './spec_helper.rb'
+require './lib/shift_finder.rb'
+require './lib/offset_maker.rb'
+require './lib/key_maker.rb'
+
+RSpec.describe ShiftFinder do
+  before(:each) do
+
+    @key_maker = KeyMaker.new("02715")
+    @offset_maker = OffsetMaker.new("040895")
+
+    @key_maker.generate_four_keys("02715")
+    @offset_maker.set_offsets
+
+    @shift_finder = ShiftFinder.new(@key_maker.keys, @offset_maker.offsets)
+  end
+
+  it 'exists' do
+    @shift_finder = ShiftFinder.new(@key_maker.keys, @offset_maker.offsets)
+    expect(@shift_finder).to be_instance_of(ShiftFinder)
+  end
+
+  it 'can sum keys and offsets' do
+    # require "pry"; binding.pry
+    expected = {"A" => "3", "B" => "27", "C" => "73", "D" => "20"}
+    expect(@shift_finder.sum_of_keys_and_offsets(@key_maker.keys, @offset_maker.offsets)).to eq(expected)
+  end
+end


### PR DESCRIPTION
Tentative creation and testing for the ShiftFinder class. Sole purpose is to add up the keys and offsets and spit back out the corresponding hash of A-D with their shifts. 