### PR TITLE
Add Module Encryptable to Enigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ to meet expectations.
   + ✔️ Simple cov shoes coverage at 100%
 
   #### Version Control
-  Total commits:
-  Uses logical pull request workflow.
+  + Total commits:
+  + Uses logical pull request workflow.
 
   #### Score I would give myself: 3

--- a/decrypted.txt
+++ b/decrypted.txt
@@ -1,0 +1,1 @@
+hello! world

--- a/encrypted.txt
+++ b/encrypted.txt
@@ -1,0 +1,1 @@
+ mcbg!hnejtv

--- a/lib/encryptable.rb
+++ b/lib/encryptable.rb
@@ -1,31 +1,23 @@
-# require './key_maker'
-# require './offset_maker'
-
 module Encryptable
-  def forward_shift(message, key, date)
-    encrypted = {}
-    shifts_array = @shift_finder.shifts.values.map {|value| value.to_i}
+  def shift_message(message, shifts_array)
+    alphabet_array = ("a".."z").to_a << " "
     encrypted_text = ""
     message.downcase!
     shift_loop = shifts_array.cycle(message.length)
       message.chars.each_with_index do |letter, index|
-        if @alphabet_array.include?(letter)
-          shift_letter_index = shift_loop.next
-          new_index = @alphabet_array.index(letter) + shift_letter_index
+        if alphabet_array.include?(letter)
+          shift_letter_amount = shift_loop.next
+          new_index = alphabet_array.index(letter) + shift_letter_amount
           new_index -= 108 if new_index > 108
           new_index -= 81 if new_index > 81
           new_index -= 54 if new_index > 54
           new_index -= 27 if new_index > 26
-          new_letter = @alphabet_array[new_index]
+          new_letter = alphabet_array[new_index]
           encrypted_text << new_letter.to_s
         elsif
           encrypted_text << letter.to_s
         end
       end
       encrypted_text
-      encrypted[:encryption] = encrypted_text
-      encrypted[:key] = @key_maker.key
-      encrypted[:date] = @offset_maker.date
-      encrypted
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,44 +1,47 @@
 require 'date'
-# require './encryptable.rb'
+require_relative './encryptable.rb'
 
 class Enigma
-  # include Encryptable
+  include Encryptable
 
-  def initialize
-    @alphabet_array = ("a".."z").to_a << " "
-  end
+  # def initialize
+  #   # @alphabet_array = ("a".."z").to_a << " "
+  # end
 
   def encrypt(message, key = nil, date = nil)
     @key_maker = KeyMaker.new(key)
     @offset_maker = OffsetMaker.new(date)
     @shift_finder = ShiftFinder.new(@key_maker.keys, @offset_maker.offsets)
     encrypted = {}
-
+    #
     shifts_array = @shift_finder.shifts.values.map {|value| value.to_i}
 
-    encrypted_text = ""
-    message.downcase!
-    shift_loop = shifts_array.cycle(message.length)
-      message.chars.each_with_index do |letter, index|
-        if @alphabet_array.include?(letter)
-          shift_letter_amount = shift_loop.next
-          new_index = @alphabet_array.index(letter) + shift_letter_amount
-          new_index -= 108 if new_index > 108
-          new_index -= 81 if new_index > 81
-          new_index -= 54 if new_index > 54
-          new_index -= 27 if new_index > 26
-          new_letter = @alphabet_array[new_index]
-          encrypted_text << new_letter.to_s
-        elsif
-          encrypted_text << letter.to_s
-        end
-      end
+    # message_encryption = shift_message(message, shifts_array)
+    #
+    # encrypted_text = ""
+    # message.downcase!
+    # shift_loop = shifts_array.cycle(message.length)
+    #   message.chars.each_with_index do |letter, index|
+    #     if @alphabet_array.include?(letter)
+    #       shift_letter_amount = shift_loop.next
+    #       new_index = @alphabet_array.index(letter) + shift_letter_amount
+    #       new_index -= 108 if new_index > 108
+    #       new_index -= 81 if new_index > 81
+    #       new_index -= 54 if new_index > 54
+    #       new_index -= 27 if new_index > 26
+    #       new_letter = @alphabet_array[new_index]
+    #       encrypted_text << new_letter.to_s
+    #     elsif
+    #       encrypted_text << letter.to_s
+    #     end
+    #   end
     #forward_shift(message, key, date)
-    encrypted_text
-    encrypted[:encryption] = encrypted_text
+    # encrypted_text
+    encrypted[:encryption] = shift_message(message, shifts_array)
     encrypted[:key] = @key_maker.key
     encrypted[:date] = @offset_maker.date
     encrypted
+    # require "pry"; binding.pry
   end
 
   def decrypt(ciphertext, key = nil, date = nil)
@@ -46,6 +49,7 @@ class Enigma
     @offset_maker = OffsetMaker.new(date)
     @shift_finder = ShiftFinder.new(@key_maker.keys, @offset_maker.offsets)
     decrypted = {}
+    @alphabet_array = ("a".."z").to_a << " "
 
     shifts_array = @shift_finder.shifts.values.map {|value| value.to_i}
 

--- a/message.txt
+++ b/message.txt
@@ -1,1 +1,1 @@
-Hello World!@
+Hello! world

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -39,8 +39,11 @@ RSpec.describe Enigma do
   end
 
   it 'can generate random keys and use the date from today' do
+    # require "pry"; binding.pry
+    # allow(@enigma).to_receive(:self.offset_maker.date).and_return("111521")
     expect(@enigma.encrypt("hello world")).to be_a(Hash)
     expect(@enigma.encrypt("hello world").count).to eq(3)
+
   end
 
   it 'can encrypt a message with other characters that stay the same' do


### PR DESCRIPTION
Here is a refactor to clean up the encrypt method. Now it should just show the use of @key-maker, @offset_maker, @shift-finder, and then the resulting encryption hash. The module takes care of the shifting. 